### PR TITLE
Minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ deploy:
     - out/initrd.img-touch-amd64
     - out/initrd.img-touch-i386
   on:
-    tags: true
     repo: Halium/initramfs-tools-halium
     branch: halium
   overwrite: true

--- a/scripts/halium
+++ b/scripts/halium
@@ -11,6 +11,17 @@ tell_kmsg() {
 	echo "initrd: $1" >/dev/kmsg || true
 }
 
+# Redefine panic since we need to do something a bit different
+# Use 'original_panic $MESSAGE' to start panic handlers
+eval "original_$(declare -f panic)"
+
+panic() {
+	# Puts panic reason into kmsg and then starts the panic handlers
+	REASON="$1"
+	tell_kmsg "PANIC for reason: $REASON"
+	original_panic $REASON
+}
+
 identify_boot_mode() {
 	# Our current list of supported boot modes:
 	## BOOT_MODE = halium and android
@@ -335,6 +346,9 @@ mountroot() {
 	run_scripts /scripts/local-premount
 	[ "$quiet" != "y" ] && log_end_msg
 
+	# Put all of this script's output into /dev/kmsg
+	exec &>/dev/kmsg
+
 	# Mount root
 	#
 	# Create a temporary mountpoint for the bindmount
@@ -445,6 +459,8 @@ mountroot() {
 		tell_kmsg "mounting android system image from system rootfs"
 		mount -o loop,$MOUNT /halium-system/var/lib/lxc/android/system.img /android-system
 	fi
+
+	[ $? -eq 0 ] || tell_kmsg "WARNING: Failed to mount Android system.img."
 
 	extract_android_ramdisk
 

--- a/scripts/halium
+++ b/scripts/halium
@@ -11,15 +11,11 @@ tell_kmsg() {
 	echo "initrd: $1" >/dev/kmsg || true
 }
 
-# Redefine panic since we need to do something a bit different
-# Use 'original_panic $MESSAGE' to start panic handlers
-eval "original_$(declare -f panic)"
-
-panic() {
+halium_panic() {
 	# Puts panic reason into kmsg and then starts the panic handlers
 	REASON="$1"
 	tell_kmsg "PANIC for reason: $REASON"
-	original_panic $REASON
+	panic $REASON
 }
 
 identify_boot_mode() {
@@ -253,7 +249,7 @@ process_bind_mounts() {
 	# Prepare the fstab
 	FSTAB=${rootmnt}/etc/fstab
 	touch ${rootmnt}/run/image.fstab
-	mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "Could not bind-mount fstab"
+	mount -o bind ${rootmnt}/run/image.fstab $FSTAB ||halium_panic "Could not bind-mount fstab"
 	echo "/dev/root / rootfs defaults,ro 0 0" >>$FSTAB
 
 	tell_kmsg "Adding bind-mounts to $FSTAB"
@@ -377,7 +373,7 @@ mountroot() {
 	fi
 
 	if [ -z "$path" ]; then
-		panic "Couldn't find data partition."
+		halium_panic "Couldn't find data partition."
 	fi
 
 	tell_kmsg "checking filesystem integrity for the userdata partition"
@@ -571,7 +567,7 @@ mountroot() {
 
 	else
 		# Possibly a re-partitioned device
-		panic "Couldn't find a system partition."
+		halium_panic "Couldn't find a system partition."
 	fi
 
 	[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/local-bottom"

--- a/scripts/panic/telnet
+++ b/scripts/panic/telnet
@@ -31,7 +31,7 @@ usb_setup() {
 	write $ANDROID_USB/idVendor 18D1
 	write $ANDROID_USB/idProduct D001
 	write $ANDROID_USB/iManufacturer "Halium initrd"
-	write $ANDROID_USB/iProduct "I hit a nail"
+	write $ANDROID_USB/iProduct "Failed to boot"
 	write $ANDROID_USB/iSerial "$1"
 	write $ANDROID_USB/functions $USB_FUNCTIONS
 	write $ANDROID_USB/enable 1


### PR DESCRIPTION
* iProduct makes more sense when the boot fails and we start telnet. Goodbye, "i hit a nail".
* Panic writes into /dev/kmsg before starting telnet
* All of our mountroot output goes into /dev/kmsg
* Warn when system.img doesn't mount