### PR TITLE
Send log messages to kmsg

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -1,5 +1,11 @@
 # Local filesystem mounting			-*- shell-script -*-
 
+_log_msg()
+{
+	if [ "$quiet" = "y" ]; then return; fi
+	printf "$@" > /dev/kmsg || true
+}
+
 pre_mountroot() {
 	[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/local-top"
 	run_scripts /scripts/local-top

--- a/scripts/halium
+++ b/scripts/halium
@@ -1,7 +1,6 @@
 # Local filesystem mounting			-*- shell-script -*-
 
-_log_msg()
-{
+_log_msg() {
 	if [ "$quiet" = "y" ]; then return; fi
 	printf "$@" > /dev/kmsg || true
 }


### PR DESCRIPTION
Overwrite _log_msg in halium boot script to send the log messages to kmsg where we can actually read them.