### PR TITLE
Add resize2fs to initramfs

### DIFF
--- a/hooks/halium
+++ b/hooks/halium
@@ -20,6 +20,7 @@ esac
 
 copy_exec /sbin/swapon /sbin
 copy_exec /sbin/e2fsck /sbin
+copy_exec /sbin/resize2fs /sbin
 copy_exec /bin/chown /bin
 copy_exec /bin/mount /bin
 copy_exec /sbin/dumpe2fs /sbin


### PR DESCRIPTION
The halium script explicitly calls resize2fs when the data/ filesystem is smaller than its filesystem, but that executable is not actually available in the image... This fixes that.