### PR TITLE
Remove duplicated moving of /tmpmnt to ${rootmnt}/userdata

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -492,8 +492,6 @@ mountroot() {
 
 		mount --move /halium-system ${rootmnt}
 
-		mount --move /tmpmnt ${rootmnt}/userdata
-
 		# Mount some tmpfs
 		mkdir -p ${rootmnt}/android
 		mount -o rw,size=4096 -t tmpfs none ${rootmnt}/android


### PR DESCRIPTION
reported by @Tofee

In case you merge it, please squash this and use the pr description as new commit name