### PR TITLE
Create a symlink to 'system/vendor' if no vendor partition is mounted

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -145,6 +145,11 @@ mount_android_partitions() {
 		tell_kmsg "mounting $path as ${mount_root}/$2"
 		mount $path ${mount_root}/$2 -t $3 -o $4
 	done
+
+	# Create an appropriate symlink for vendor files
+	if [ ! -e ${mount_root}/vendor ]; then
+		ln -sf system/vendor ${mount_root}/vendor
+	fi
 }
 
 mount_halium_overlay() {


### PR DESCRIPTION
I've recently made [commits to lxc-android's packaging](https://github.com/debian-pm/lxc-android-packaging/pull/1) that create symlinks from each of `cache data factory firmware persist system vendor` to their equivalent in `/android`. The problem is, this causes problems for some devices which expect `/vendor` to be a symlink to `/system/vendor` rather than missing. This small change ensures that `vendor/` is symlinked to `system/vendor` inside of the selected mount directory for mount_android_partitions.