### PR TITLE
Add support for mounting non-ext4 partitions

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -409,8 +409,9 @@ mountroot() {
 	tell_kmsg "mounting $path"
 
 	# Mount the data partition to a temporary mount point
-	# FIXME: data=journal used as a workaround for bug 1387214
-	mount -o discard,data=journal $path /tmpmnt
+	# FIXME: data=journal used on ext4 as a workaround for bug 1387214
+	[ `blkid $path -o value -s TYPE` = "ext4" ] && OPTIONS="data=journal,"
+	mount -o discard,$OPTIONS $path /tmpmnt
 
 	# Set $_syspart if it is specified as systempart= on the command line
 	if grep -q systempart= /proc/cmdline; then


### PR DESCRIPTION
By looking before mounting, we can turn off `data=journal` for non-ext4 partitions and allow the mount of anything else (like f2fs or whatever other FS the porter wants to use)