### PR TITLE
Always move android rootfs mount in android mode

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -533,7 +533,7 @@ mountroot() {
 		# Bootloader says this is factory or charger mode, boot into Android.
 		tell_kmsg "Android boot mode for factory or charger mode"
 
-		[ $ANDROID_IMAGE_MODE = "rootfs" ] && mount --move /android-rootfs ${rootmnt}
+		mount --move /android-rootfs ${rootmnt}
 		[ $ANDROID_IMAGE_MODE = "system" ] && mount --move /android-system ${rootmnt}/system
 
 		# Mount all the Android partitions


### PR DESCRIPTION
Commit 19039a3964b9f1d528892bc5ac1e594b4d6b0778 (Implement basic support
for A/B devices) breaks booting into android mode on devices with
android system image by not moving android rootfs into root mountpoint.
This commit remove the condition check and make mountpoint moving
unconditional.