### PR TITLE
Add additional file layout for legacy boot mode

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -271,6 +271,9 @@ identify_file_layout() {
 	if [ -e /tmpmnt/rootfs.img ]; then
 		imagefile=/tmpmnt/rootfs.img
 		file_layout="halium"
+	elif [ -e /tmpmnt/ubuntu.img ]; then
+		imagefile=/tmpmnt/ubuntu.img
+		file_layout="legacy"
 	elif [ -d /tmpmnt/halium-rootfs ]; then
 		imagefile=/tmpmnt/halium-rootfs
 		file_layout="subdir"


### PR DESCRIPTION
The legacy file layout will be needed for the system-image client, for devices where the system partition is smaller than 2GB, like Oneplus One. It allows to have a) the rootfs named ubuntu.img again, b) it will search then for the system.img inside this ubuntu.img