### PR TITLE
halium: fix slot suffix missing on syspart for some devices

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -487,6 +487,15 @@ mountroot() {
 		done
 	fi
 
+	ab_slot_suffix=$(grep -o 'androidboot\.slot_suffix=..' /proc/cmdline |  cut -d "=" -f2)
+
+	# On A/B devices, the system partition name ends in a slot suffix.
+	# To allow boot images to remain slot agnostic, check that the systempart
+	# does NOT contain a slot suffix, and add it if so.
+	if [ ! $(echo $_syspart | grep -qe "^.*_[ab]$") ] && [ ! -z "$_syspart" ]; then
+		_syspart="$_syspart$ab_slot_suffix"
+	fi
+
 	identify_file_layout
 
 	# If both $imagefile and $_syspart are set, something is wrong. The strange


### PR DESCRIPTION
Some A/B devices (OnePlus 6) have the systempart cmdline but don't
specify a slot suffix in order to avoid requiring that ubports be flashed to a particular slot, leading to the initramfs attempting to mount a partition that doesn't exist.

We check if there is a suffix specified and append `$ab_slot_suffix` otherwise. This shouldn't affect non-A/B devices as `$ab_slot_suffix` will be empty.