### PR TITLE
Allow fake cache mounting even if root/cache exists by using flag file

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -185,7 +185,7 @@ mount_android_partitions() {
 	done
 
 	# Provide a bind mount from /cache to /userdata/cache on systems without a dedicated cache partition
-	if [ ! -e ${mount_root}/cache] || [ -e ${mount_root}/cache-disabled ]; then
+	if [ ! -e ${mount_root}/cache ] || ! grep -q "${mount_root}/cache" /proc/mounts; then
 		if [ ! -d ${real_userdata}/cache ]; then
 			mkdir ${real_userdata}/cache
 		fi

--- a/scripts/halium
+++ b/scripts/halium
@@ -185,7 +185,7 @@ mount_android_partitions() {
 	done
 
 	# Provide a bind mount from /cache to /userdata/cache on systems without a dedicated cache partition
-	if [ ! -e ${mount_root}/cache ]; then
+	if [ ! -e ${mount_root}/cache] || [ -e ${mount_root}/cache-disabled ]; then
 		if [ ! -d ${real_userdata}/cache ]; then
 			mkdir ${real_userdata}/cache
 		fi


### PR DESCRIPTION
Since some Android 9 devices have again too small cache partition we need to indicate that /cache folder should be ignored.