### PR TITLE
scripts: mount writable things in /etc in initrd

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -369,12 +369,22 @@ process_bind_mounts() {
 				sync_dirs $dstpath . $srcpath
 			fi
 
-			# Write the fstab entry
 			if [ "$5" = "none" ]; then
-				echo "$path $1 none bind 0 0" >>$FSTAB
+				mount_opts="bind"
 			else
-				echo "$path $1 none bind,$5 0 0" >>$FSTAB
+				mount_opts="bind,$5"
 			fi
+
+			# mount all /etc dirs right now, not later when fstab is
+			# processed, as it will cause races (e.g. /etc/machine-id).
+			case "$1" in
+				/etc/*)
+					mount -o "$mount_opts" "$srcpath" "$dstpath"
+					;;
+				*)
+					echo "$path $1 none $mount_opts 0 0" >>$FSTAB
+					;;
+			esac
 		else
 			continue
 		fi


### PR DESCRIPTION
Otherwise it will cause races with various things. For example, systemd
processes /etc/machine-id early in its initialization process.

Ubuntu Core (snap-based) does this too. However, the implementation is
slightly different.
https://github.com/snapcore/core20/blob/master/static/usr/lib/core/handle-writable-paths#L124

---

Open questions:
- You'll notice that in Ubuntu Core, the file that handle writable-paths resides in the rootfs/core snap. Should we follow suite?
- How should we handle:
  - Old systems with un-upgradable [1] boot.img (e.g. bq Aquaris E4.5), or simply the one that haven't been updated yet.
  - Initrd-less systems (jumpercable)?

[1] Technically we can extract & re-pack the old image, but I would prefer not to do that.