### PR TITLE
build-initrd: correctly creating chroot's root

### DIFF
--- a/build-initrd.sh
+++ b/build-initrd.sh
@@ -71,7 +71,7 @@ if [ ! -e $ROOT/.min-done ]; then
 
 	# create a plain chroot to work in
 	echob "Creating chroot with arch $ARCH in $ROOT"
-	mkdir build || true
+	mkdir -p "$ROOT"
 	$BOOTSTRAP_BIN $RELEASE $ROOT $MIRROR || cat $ROOT/debootstrap/debootstrap.log
 
 	#sed -i 's/main$/main universe/' $ROOT/etc/apt/sources.list


### PR DESCRIPTION
Don't hard-coded "build" dir, or it'll fail when the root is overridden.