### PR TITLE
scripts/halium: deal with (broken) symlink in sync_dirs

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -225,7 +225,7 @@ sync_dirs() {
 
 	for file in $source/*; do
 		# Skip empty directories
-		[ ! -e "$base/$file" ] && continue
+		[ ! -e "$base/$file" -a ! -L "$base/$file" ] && continue
 
 		# If the target already exists as a file or link, there's nothing we can do
 		[ -e "$target/$file" -o -L "$target/$file" ] && [ ! -d "$target/$file" ] && continue


### PR DESCRIPTION
This is our version of [1] from Snap's initramfs. The original commit read:

> The sync_dirs() has a test -e that fails to take broken symlinks
> into account. This means that symlinks that are broken when
> sync_dir runs (which is a very special environment) are not
> copied. This breaks e.g. the symlink snapd.snap-repair.timer
> in /etc/systemd/system/timer-target.wants.

In our case, we want this so that having `/etc/systemd` on
writable-paths' `synced` mode works properly.

[1] https://github.com/snapcore/core-build/commit/843b8c7bb147a58cefb605487de39c5e14892099