### PR TITLE
scripts/halium: fix super partition detection logic

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -487,7 +487,7 @@ mountroot() {
 	mount -o discard,$OPTIONS $path /tmpmnt
 
 	# setup super partition if exists
-	if [ -n "/dev/disk/by-partlabel/super" ]; then
+	if [ -b /dev/disk/by-partlabel/super ]; then
 		tell_kmsg "trying to parse and dmsetup subpartitions from super partition"
 		/sbin/parse-android-dynparts /dev/disk/by-partlabel/super | sh
 	fi


### PR DESCRIPTION
`test -n` just checks if `the length of STRING is nonzero` which obviously is wrong when the existence of a path is in question.

Replace it with `test -b` which is true if `FILE exists and is block special`

Initramfs test on Volla Phone X23:
```
/ # ls -l /dev/disk/by-partlabel/super
lrwxrwxrwx    1 0        0               11 May 13 13:37 /dev/disk/by-partlabel/super -> ../../sdc57
/ # [ -b /dev/disk/by-partlabel/super ] && echo true
true
  ```