### PR TITLE
Integrate mke2fs tool into ramdisk + fix build

### DIFF
--- a/build-initrd.sh
+++ b/build-initrd.sh
@@ -4,7 +4,7 @@ set -e
 
 export FLASH_KERNEL_SKIP=1
 export DEBIAN_FRONTEND=noninteractive
-DEFAULTMIRROR="https://deb.debian.org/debian"
+DEFAULTMIRROR="https://archive.debian.org/debian"
 DEFAULTUBPORTSMIRROR="http://repo.ubports.com/"
 UBPORTSKEYRING="https://repo.ubports.com/keyring.gpg"
 APT_COMMAND="apt -y"

--- a/hooks/halium
+++ b/hooks/halium
@@ -21,6 +21,7 @@ esac
 copy_exec /sbin/swapon /sbin
 copy_exec /sbin/e2fsck /sbin
 copy_exec /sbin/resize2fs /sbin
+copy_exec /sbin/mke2fs /sbin
 copy_exec /bin/chown /bin
 copy_exec /bin/mount /bin
 copy_exec /sbin/dmsetup /sbin

--- a/scripts/halium
+++ b/scripts/halium
@@ -466,6 +466,12 @@ mountroot() {
 		halium_panic "Couldn't find data partition."
 	fi
 
+	# Format a wiped userdata without a filesystem header
+	if head -c 4096 $path | cmp /dev/zero 2>&1 | grep -q '^cmp: EOF on -$'; then
+		tell_kmsg "formatting wiped $path as ext4..."
+		mke2fs -t ext4 $path || halium_panic "Failed to format wiped userdata."
+	fi
+
 	tell_kmsg "checking filesystem integrity for the userdata partition"
 	# Mounting and umounting first, let the kernel handle the journal and
 	# orphaned inodes (faster than e2fsck). Then, just run e2fsck forcing -y.


### PR DESCRIPTION
`mke2fs` will be used to properly format e.g. `fastboot erase userdata` or freshly wiped userdata partition from bootloader unlock as needed; checks only the fully-zeroed case from https://github.com/LineageOS/android_system_core/blob/lineage-22.1/libcutils/partition_utils.cpp#L42