### PR TITLE
telnet: use NCM configfs function for USB network if available

### DIFF
--- a/scripts/panic/telnet
+++ b/scripts/panic/telnet
@@ -35,9 +35,16 @@ usb_setup_configfs() {
     write $GADGET_DIR/g1/strings/0x409/manufacturer "Halium initrd"
     write $GADGET_DIR/g1/strings/0x409/product      "Failed to boot"
 
+    NETWORK_FUNCTION=""
     if echo $USB_FUNCTIONS | grep -q "rndis"; then
-        mkdir $GADGET_DIR/g1/functions/rndis.usb0
-        mkdir $GADGET_DIR/g1/functions/rndis_bam.rndis
+        for function in ncm.usb0 rndis.usb0 rndis_bam.rndis; do
+            mkdir $GADGET_DIR/g1/functions/$function && NETWORK_FUNCTION=$function && break
+        done
+
+        if [ -z "$NETWORK_FUNCTION" ]; then
+            echo "Error: No USB network gadget function available" >&2
+            exit 1
+        fi
     fi
     echo $USB_FUNCTIONS | grep -q "mass_storage" && mkdir $GADGET_DIR/g1/functions/storage.0
 
@@ -46,8 +53,7 @@ usb_setup_configfs() {
     write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "$USB_FUNCTIONS"
 
     if echo $USB_FUNCTIONS | grep -q "rndis"; then
-        ln -s $GADGET_DIR/g1/functions/rndis.usb0 $GADGET_DIR/g1/configs/c.1
-        ln -s $GADGET_DIR/g1/functions/rndis_bam.rndis $GADGET_DIR/g1/configs/c.1
+        ln -s $GADGET_DIR/g1/functions/$NETWORK_FUNCTION $GADGET_DIR/g1/configs/c.1
     fi
     echo $USB_FUNCTIONS | grep -q "mass_storage" && ln -s $GADGET_DIR/g1/functions/storage.0 $GADGET_DIR/g1/configs/c.1
 


### PR DESCRIPTION
Needed on newer device as they now have NCM enabled in kernel config by default, but not RNDIS (which is now deprecated).