### PR TITLE
Unbreak CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: [armhf, arm64, amd64]
@@ -28,7 +28,7 @@ jobs:
 
   upload:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:


### PR DESCRIPTION
Technically something even fancier could be done nowadays for the ARM side with https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview existing but that can be looked into later; for now Let's at least get new `dynparts` initramfs artifacts flowing again