### PR TITLE
Bump actions to attempt fixing dynparts artifact uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Download all built artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       # Here we're abusing the "continuous" tag/release to store the latest
       # built image. This is not very good practice, but GitHub won't allow
       # unauthenticated user to download artifacts. Hence, this abuse.
 
       - name: Release to the continuous tag.
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: halium-initramfs-*/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
https://github.com/Halium/initramfs-tools-halium/releases/tag/dynparts source is now updated but the artifcts still weren't due to the https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ related failure seen in e.g. https://github.com/Halium/initramfs-tools-halium/actions/runs/15511412449/job/43672953653; let's try just bumping the actions to their current latest versions to attempt fixing this:
- https://github.com/marketplace/actions/download-a-build-artifact
- https://github.com/marketplace/actions/gh-release