### PR TITLE
Add LVM volume group support if lvm_vg= is specified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ jobs:
     strategy:
       matrix:
         arch: [armhf, arm64, amd64]
+        # Same scripts either way, the LVM build just also ships lvm2.
+        variant:
+          - suffix: ""
+            lvm: 0
+          - suffix: "-lvm"
+            lvm: 1
 
     steps:
       - name: Checkout
@@ -18,12 +24,12 @@ jobs:
           sudo apt-get install qemu-user-static debootstrap -y
 
       - name: Build initramfs
-        run: sudo ARCH=${{ matrix.arch }} ./build-initrd.sh
+        run: sudo ARCH=${{ matrix.arch }} LVM=${{ matrix.variant.lvm }} ./build-initrd.sh
 
       - name : Upload artifacts
         uses: actions/upload-artifact@master
         with:
-          name: halium-initramfs-${{ matrix.arch }}
+          name: halium-initramfs-${{ matrix.arch }}${{ matrix.variant.suffix }}
           path: out/
 
   upload:

--- a/build-initrd.sh
+++ b/build-initrd.sh
@@ -43,11 +43,22 @@ done
 [ -z $UBPORTSMIRROR ] && UBPORTSMIRROR=$DEFAULTUBPORTSMIRROR
 [ -z $RELEASE ] && RELEASE="stretch"
 [ -z $UBPORTSRELEASE ] && UBPORTSRELEASE="xenial"
-[ -z $ROOT ] && ROOT=./build/$ARCH
+[ -z $LVM ] && LVM=0
 [ -z $OUT ] && OUT=./out
 
+# LVM costs ramdisk size, so it is opt-in via LVM=1. Installing lvm2 is the only
+# difference. Use a separate chroot per variant, or it leaks into a later LVM=0 build.
+LVMPKGS=""
+VARIANT=""
+if [ "$LVM" = "1" ]; then
+	LVMPKGS="lvm2"
+	VARIANT="-lvm"
+fi
+
+[ -z $ROOT ] && ROOT=./build/$ARCH$VARIANT
+
 # list all packages needed for halium's initrd here
-[ -z $INCHROOTPKGS ] && INCHROOTPKGS="initramfs-tools dctrl-tools dmsetup e2fsprogs libc6-dev lvm2 zlib1g-dev libssl-dev busybox-static parse-android-dynparts"
+[ -z $INCHROOTPKGS ] && INCHROOTPKGS="initramfs-tools dctrl-tools dmsetup e2fsprogs libc6-dev $LVMPKGS zlib1g-dev libssl-dev busybox-static parse-android-dynparts"
 
 BOOTSTRAP_BIN="qemu-debootstrap --arch $ARCH --variant=minbase"
 
@@ -115,7 +126,7 @@ cp -a conf/halium ${ROOT}/usr/share/initramfs-tools/conf.d
 cp -a scripts/* ${ROOT}/usr/share/initramfs-tools/scripts
 cp -a hooks/* ${ROOT}/usr/share/initramfs-tools/hooks
 
-VER="$ARCH"
+VER="$ARCH$VARIANT"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib/$DEB_HOST_MULTIARCH"
 
 do_chroot $ROOT "update-initramfs -tc -ktouch-$VER -v"

--- a/build-initrd.sh
+++ b/build-initrd.sh
@@ -47,7 +47,7 @@ done
 [ -z $OUT ] && OUT=./out
 
 # list all packages needed for halium's initrd here
-[ -z $INCHROOTPKGS ] && INCHROOTPKGS="initramfs-tools dctrl-tools dmsetup e2fsprogs libc6-dev zlib1g-dev libssl-dev busybox-static parse-android-dynparts"
+[ -z $INCHROOTPKGS ] && INCHROOTPKGS="initramfs-tools dctrl-tools dmsetup e2fsprogs libc6-dev lvm2 zlib1g-dev libssl-dev busybox-static parse-android-dynparts"
 
 BOOTSTRAP_BIN="qemu-debootstrap --arch $ARCH --variant=minbase"
 

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Depends: initramfs-tools,
          coreutils,
          busybox-static,
          e2fsprogs,
+         lvm2,
          ${misc:Depends}
 Description: tools for mounting an Ubuntu Touch rootfs
  This package contains the scripts to boot an Ubuntu Touch device.

--- a/debian/initramfs-tools-halium.postinst
+++ b/debian/initramfs-tools-halium.postinst
@@ -5,7 +5,7 @@ set -e
 apply_diversions() {
 	DIR=/usr/share/initramfs-tools
 	SUBDIRS="hooks scripts/local-premount scripts/init-top scripts/init-bottom scripts/panic"
-	FILES="compcache fixrtc dmsetup plymouth console_setup kbd thermal"
+	FILES="compcache fixrtc plymouth console_setup kbd thermal"
 
 	for file in $FILES; do
 		for subdir in $SUBDIRS; do

--- a/hooks/halium
+++ b/hooks/halium
@@ -28,7 +28,11 @@ copy_exec /bin/chown /bin
 copy_exec /bin/mount /bin
 copy_exec /sbin/dmsetup /sbin
 copy_exec /sbin/dumpe2fs /sbin
-copy_exec /sbin/lvm /sbin
+# LVM is optional to save ramdisk size, and only included when lvm2 is installed here
+# (LVM=1 in build-initrd.sh). Without it scripts/halium just uses the partitions.
+if [ -x /sbin/lvm ]; then
+	copy_exec /sbin/lvm /sbin
+fi
 copy_exec /lib/$DEB_HOST_MULTIARCH/libz.so.1
 copy_exec /usr/lib/$DEB_HOST_MULTIARCH/libcrypto.so
 copy_exec /usr/lib/$DEB_HOST_MULTIARCH/libdl.so

--- a/hooks/halium
+++ b/hooks/halium
@@ -1,6 +1,8 @@
 #!/bin/sh -e
 
 MINKVER="2.6.24"
+# Keep this empty. A prereq puts us in a later pass than zz-busybox, and copy_exec does
+# not overwrite, so mount, chown and swapon would stay busybox applets.
 PREREQ=""
 DEB_HOST_MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
 
@@ -26,6 +28,7 @@ copy_exec /bin/chown /bin
 copy_exec /bin/mount /bin
 copy_exec /sbin/dmsetup /sbin
 copy_exec /sbin/dumpe2fs /sbin
+copy_exec /sbin/lvm /sbin
 copy_exec /lib/$DEB_HOST_MULTIARCH/libz.so.1
 copy_exec /usr/lib/$DEB_HOST_MULTIARCH/libcrypto.so
 copy_exec /usr/lib/$DEB_HOST_MULTIARCH/libdl.so

--- a/scripts/halium
+++ b/scripts/halium
@@ -463,36 +463,61 @@ mountroot() {
 	# Make sure the device has been created by udev before we try to mount
 	udevadm settle
 
-	# find the right partition
-	for partname in $partlist; do
-		part=$(find /dev -name $partname | tail -1)
-		[ -z "$part" ] && continue
-		path=$(readlink -f $part)
-		[ -n "$path" ] && break
-	done
-
 	# On systems with A/B partition layout, current slot is provided via cmdline parameter.
 	ab_slot_suffix=$(grep -o 'androidboot\.slot_suffix=..' /proc/cmdline | tail -1 | cut -d "=" -f2)
-	if [ -z "$path" ] && [ ! -z "$ab_slot_suffix" ] ; then
-		tell_kmsg "Searching for A/B data partition on slot $ab_slot_suffix."
 
+	# Check for LVM volume group in kernel cmdline and activate LVM
+	vg=""
+	for x in $(cat /proc/cmdline); do
+		case ${x} in
+		halium_lvm_vg=*)
+			vg=${x#*=}
+			;;
+		esac
+	done
+
+	# Try each volume group from comma-separated list, use first existing one
+	if [ -n "$vg" ]; then
+		OLDIFS=$IFS
+		IFS=','
+		found_vg=""
+		for vg_candidate in $vg; do
+			if lvm vgs "$vg_candidate" >/dev/null 2>&1; then
+				found_vg="$vg_candidate"
+				tell_kmsg "Volume group $found_vg found"
+				break
+			fi
+		done
+		IFS=$OLDIFS
+		if [ -z "$found_vg" ]; then
+			tell_kmsg "WARNING: None of the specified volume groups found ($vg)"
+		fi
+		vg="$found_vg"
+	fi
+
+	# First check if LVM volume group has userdata
+	if [ -n "$vg" ] && [ -e "/dev/$vg/userdata" ]; then
+		tell_kmsg "Using LVM userdata volume at /dev/$vg/userdata"
+		path="/dev/$vg/userdata"
+	else
+		# Find the right partition for userdata
 		for partname in $partlist; do
-			part=$(find /dev -name "$partname$ab_slot_suffix" | tail -1)
+			part=$(find /dev -name $partname | tail -1)
 			[ -z "$part" ] && continue
 			path=$(readlink -f $part)
 			[ -n "$path" ] && break
 		done
-	fi
 
-	# override with a possible cmdline parameter
-	if grep -q datapart= /proc/cmdline; then
-		for x in $(cat /proc/cmdline); do
-			case ${x} in
-			datapart=*)
-				path=${x#*=}
-				;;
-			esac
-		done
+		# Override with a possible cmdline parameter
+		if grep -q datapart= /proc/cmdline; then
+			for x in $(cat /proc/cmdline); do
+				case ${x} in
+				datapart=*)
+					path=${x#*=}
+					;;
+				esac
+			done
+		fi
 	fi
 
 	if [ -z "$path" ]; then
@@ -546,6 +571,16 @@ mountroot() {
 			esac
 		done
 
+		if [ -z "$_syspart_options" ]; then
+			_syspart_options=rw
+		fi
+	fi
+
+	# Override systempart with LVM rootfs if volume group is provided
+	if [ -n "$vg" ] && [ -e "/dev/$vg/rootfs" ]; then
+		tell_kmsg "Overriding systempart with LVM rootfs at /dev/$vg/rootfs"
+		_syspart="/dev/$vg/rootfs"
+		# Keep existing options if they were set, otherwise use rw
 		if [ -z "$_syspart_options" ]; then
 			_syspart_options=rw
 		fi

--- a/scripts/halium
+++ b/scripts/halium
@@ -72,7 +72,7 @@ identify_boot_mode() {
 	fi
 
 	# System-as-root or a device without dedicated recovery partition
-	if [ -f /ramdisk-recovery.img ] && [ -z "$normal_boot" ]; then
+	if ([ -f /ramdisk-recovery.img ] || [ -f /ramdisk-recovery.cpio.xz ]) && [ -z "$normal_boot" ]; then
 		BOOT_MODE="recovery"
 	fi
 
@@ -703,8 +703,16 @@ mountroot() {
 			mkdir -p lib/modules
 			mv /lib/modules/* lib/modules/
 		fi
-		gzip -dc /ramdisk-recovery.img | cpio -i
+		if [ -f /ramdisk-recovery.cpio.xz ]; then
+			xz -dc /ramdisk-recovery.cpio.xz | cpio -i
+		else
+			gzip -dc /ramdisk-recovery.img | cpio -i
+		fi
 		cd -
+
+		# run-init looks for /sbin/init, the recovery ramdisk only has /init
+		mkdir -p ${rootmnt}/sbin
+		[ -e ${rootmnt}/sbin/init ] || ln -s ../init ${rootmnt}/sbin/init
 	elif ([ -e $imagefile ] || [ -n "$_syspart" ]) && [ "$BOOT_MODE" = "android" ]; then
 		# Bootloader says this is factory or charger mode, boot into Android.
 		tell_kmsg "Android boot mode for factory or charger mode"

--- a/scripts/halium
+++ b/scripts/halium
@@ -270,10 +270,22 @@ resize_userdata_if_needed() {
 
 	path=$1
 
+	# Resolve to the kernel name /proc/partitions actually lists: $path is a symlink
+	# for LVM logical volumes (/dev/$vg/userdata -> /dev/dm-0).
+	devname=$(basename $(readlink -f $path))
+
 	# Partition size in 1k blocks
-	pblocks=$(grep ${path##*/} /proc/partitions | awk {'print $3'})
+	pblocks=$(grep -w "$devname" /proc/partitions | awk {'print $3'})
 	# Filesystem size in 4k blocks
 	fsblocks=$(dumpe2fs -h $path | grep "Block count" | awk {'print $3'})
+
+	# Bail out unless both sizes are known. An empty $fsblocks would otherwise leave
+	# $dblocks equal to $pblocks and point resize2fs at a device holding no filesystem.
+	if [ -z "$pblocks" ] || [ -z "$fsblocks" ]; then
+		tell_kmsg "could not determine partition/filesystem size for $path, skipping resize"
+		return
+	fi
+
 	# Difference between the reported sizes in 1k blocks
 	dblocks=$((pblocks - 4 * fsblocks))
 	if [ $dblocks -gt 10000 ]; then
@@ -522,6 +534,16 @@ mountroot() {
 
 	if [ -z "$path" ]; then
 		halium_panic "Couldn't find data partition."
+	fi
+
+	# When LVM support is missing from the ramdisk, or halium_lvm_vg= is unset or names the
+	# wrong group, the search above silently falls back to the raw partition, which on an
+	# LVM device is the physical volume itself. Everything below then treats the PV as
+	# userdata: e2fsck picks up a stale ext4 backup superblock left over from before the
+	# conversion, restores that filesystem over the PV, and writes group descriptors at
+	# offset 4096, taking the LVM metadata area and the whole volume group with it.
+	if [ "$(blkid $path -o value -s TYPE)" = "LVM2_member" ]; then
+		halium_panic "$path is an LVM physical volume, but no volume group was activated. Pass halium_lvm_vg=<vg> on the kernel cmdline and make sure the ramdisk includes LVM support."
 	fi
 
 	# Format a wiped userdata without a filesystem header


### PR DESCRIPTION
Support LVM-backed userdata and rootfs partitions via lvm_vg= cmdline parameter. Activate LVM early in boot process and check for volumes in the specified volume group. If found, /dev/$vg/userdata is used for userdata and /dev/$vg/rootfs overrides any systempart= setting.