### PR TITLE
GKI and recovery-as-boot support (finally)

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -44,6 +44,12 @@ identify_boot_mode() {
 		androidboot.force_normal_boot=1)
 			normal_boot="y"
 			;;
+		# Android 12+ (GKI 2.0+) recovery-as-boot
+		bootconfig)
+			if grep -q 'androidboot.force_normal_boot = "1"' /proc/bootconfig; then
+				normal_boot="y"
+			fi
+			;;
 		esac
 	done
 

--- a/scripts/halium
+++ b/scripts/halium
@@ -265,14 +265,7 @@ resize_userdata_if_needed() {
 	path=$1
 
 	# Partition size in 1k blocks
-	case $path in
-	/dev/mmcblk*)
-		pblocks=$(grep ${path#/dev/*} /proc/partitions | awk {'print $3'})
-		;;
-	/dev/disk*)
-		pblocks=$(grep $(basename $(readlink $path)) /proc/partitions | awk {'print $3'})
-		;;
-	esac
+	pblocks=$(grep ${path##*/} /proc/partitions | awk {'print $3'})
 	# Filesystem size in 4k blocks
 	fsblocks=$(dumpe2fs -h $path | grep "Block count" | awk {'print $3'})
 	# Difference between the reported sizes in 1k blocks

--- a/scripts/halium
+++ b/scripts/halium
@@ -642,6 +642,10 @@ mountroot() {
 
 		mount -n -t tmpfs tmpfs ${rootmnt}
 		cd ${rootmnt}
+		if [ -d /lib/modules ]; then
+			mkdir -p lib/modules
+			mv /lib/modules/* lib/modules/
+		fi
 		gzip -dc /ramdisk-recovery.img | cpio -i
 		cd -
 	elif ([ -e $imagefile ] || [ -n "$_syspart" ]) && [ "$BOOT_MODE" = "android" ]; then

--- a/scripts/halium
+++ b/scripts/halium
@@ -36,6 +36,14 @@ identify_boot_mode() {
 		androidboot.mode=*)
 			android_bootmode=${x#*=}
 			;;
+		# Android 9 system-as-root
+		skip_initramfs)
+			normal_boot="y"
+			;;
+		# Android 10+ recovery-as-boot
+		androidboot.force_normal_boot=1)
+			normal_boot="y"
+			;;
 		esac
 	done
 
@@ -55,6 +63,11 @@ identify_boot_mode() {
 		8) BOOT_MODE="android" ;; # Power off charging
 		9) BOOT_MODE="android" ;; # Low power charging
 		esac
+	fi
+
+	# System-as-root or a device without dedicated recovery partition
+	if [ -f /ramdisk-recovery.img ] && [ -z "$normal_boot" ]; then
+		BOOT_MODE="recovery"
 	fi
 
 	# On Android 8+ devices the 'android' boot mode is broken and should be avoided.
@@ -599,7 +612,18 @@ mountroot() {
 	identify_boot_mode
 
 	# Determine whether we should boot to rootfs or Android
-	if ([ -e $imagefile ] || [ -n "$_syspart" ]) && [ "$BOOT_MODE" = "android" ]; then
+	if [ "$BOOT_MODE" = "recovery" ]; then
+		tell_kmsg "Recovery boot mode for system-as-root devices"
+
+		# Clean up mounted partitions so recovery can manage them
+		umount -d /android-system /android-rootfs /halium-system /tmpmnt
+		dmsetup remove_all
+
+		mount -n -t tmpfs tmpfs ${rootmnt}
+		cd ${rootmnt}
+		gzip -dc /ramdisk-recovery.img | cpio -i
+		cd -
+	elif ([ -e $imagefile ] || [ -n "$_syspart" ]) && [ "$BOOT_MODE" = "android" ]; then
 		# Bootloader says this is factory or charger mode, boot into Android.
 		tell_kmsg "Android boot mode for factory or charger mode"
 

--- a/scripts/halium
+++ b/scripts/halium
@@ -415,6 +415,23 @@ mount_kernel_modules() {
 	[ -e ${rootmnt}/android/system/lib/modules ] && mount --bind ${rootmnt}/android/system/lib/modules ${rootmnt}/lib/modules
 }
 
+load_kernel_modules() {
+	mkdir -p /lib/modules
+	cd /lib/modules
+	ln -sf /lib/modules "/lib/modules/$(uname -r)"
+
+	tell_kmsg "Loading kernel modules from $(pwd)"
+
+	cat modules.load | while read line; do
+		set -- $line
+		# Skip commented entries
+		[ "$1" = "#" ] && continue
+		modprobe -a "$1"
+	done
+
+	cd -
+}
+
 mountroot() {
 	# list of possible userdata partition names
 	partlist="userdata UDA DATAFS USERDATA"
@@ -427,6 +444,10 @@ mountroot() {
 
 	# Put all of this script's output into /dev/kmsg
 	exec &>/dev/kmsg
+
+	load_kernel_modules
+	tell_kmsg "Finished loading kernel modules"
+	sleep 1
 
 	# Mount root
 	#
@@ -502,6 +523,7 @@ mountroot() {
 	if [ -b /dev/disk/by-partlabel/super ]; then
 		tell_kmsg "trying to parse and dmsetup subpartitions from super partition"
 		/sbin/parse-android-dynparts /dev/disk/by-partlabel/super | sh
+		dmsetup mknodes
 	fi
 
 	# Set $_syspart if it is specified as systempart= on the command line

--- a/scripts/panic/telnet
+++ b/scripts/panic/telnet
@@ -51,7 +51,7 @@ usb_setup_configfs() {
     fi
     echo $USB_FUNCTIONS | grep -q "mass_storage" && ln -s $GADGET_DIR/g1/functions/storage.0 $GADGET_DIR/g1/configs/c.1
 
-    echo "$(ls /sys/class/udc)" > $GADGET_DIR/g1/UDC
+    echo "$(ls /sys/class/udc | grep -v dummy | head -1)" > $GADGET_DIR/g1/UDC
 }
 
 # This sets up the USB with whatever USB_FUNCTIONS are set to via android_usb


### PR DESCRIPTION
Stuff like this has been overlayed across most newer Ubuntu Touch ports at this point (e.g. https://gitlab.com/ubports/porting/reference-device-ports/halium12/volla-x23/volla-vidofnir/-/commits/main/ramdisk-overlay), I think it's time to bring the relevant bits back upstream here so we can stop vendoring things so much at long last which also should ease the LVM enablement steps where relevant.

Drafting for now to check if we need anything more still here.