### PR TITLE
scripts/halium: mirror androidboot.* to /run/bootconfig

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -320,6 +320,23 @@ identify_file_layout() {
 
 }
 
+propagate_android_bootconfig() {
+	# Kernels without /proc/bootconfig pass androidboot.* on the command
+	# line; mirror them so bootconfig consumers can fall back to /run.
+
+	[ -e /proc/bootconfig ] && return 0
+
+	for x in $(cat /proc/cmdline); do
+		case ${x} in
+		androidboot.*=*)
+			echo "${x%%=*} = \"${x#*=}\""
+			;;
+		esac
+	done >${rootmnt}/run/bootconfig
+
+	tell_kmsg "no /proc/bootconfig, mirrored androidboot.* to /run/bootconfig"
+}
+
 process_bind_mounts() {
 	# Goes over /etc/system-image/writable-paths to create the correct fstab for
 	# the bind-mounts. Writes them into ${rootmnt}/run/image.fstab which is
@@ -768,6 +785,7 @@ mountroot() {
 		tell_kmsg "device is $device"
 
 		process_bind_mounts
+		propagate_android_bootconfig
 
 		# Mount all the Android partitions
 		mount_android_partitions "${rootmnt}/var/lib/lxc/android/rootfs/fstab*" ${rootmnt}/android ${rootmnt}/userdata


### PR DESCRIPTION
Kernels without `/proc/bootconfig` pass `androidboot.*` on the kernel command
line, so consumers that only read `/proc/bootconfig` never see them.

Mirror the `androidboot.*` parameters into `/run/bootconfig`, in the same
format, when `/proc/bootconfig` is absent. It runs after the `/run` tmpfs is
set up so the file survives into the booted system, and it is a no-op on
kernels that provide the real one.

The consumer side is
https://gitlab.com/ubports/development/core/hybris-support/lxc-android-config/-/merge_requests/205
